### PR TITLE
Fix missing dependency on scribble-text-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -15,6 +15,7 @@
                      "net-lib"
                      "rackunit-lib"
                      "scribble-html-lib"
+                     "scribble-text-lib"
                      "srfi-lite-lib"
                      "web-server-lib"))
 


### PR DESCRIPTION
The package server complains about a missing dependency that gets fixed here.